### PR TITLE
Update the return type of Invoker::process() method

### DIFF
--- a/src/Patterns/Command/Invoker.php
+++ b/src/Patterns/Command/Invoker.php
@@ -10,10 +10,11 @@ class Invoker
 	/**
 	 * @param string $Action
 	 * @param array|null $Params
-	 * @return bool
+	 * @return mixed
+	 * @throws CommandNotFoundException
 	 * @throws EmptyActionParameterException
 	 */
-	public function process(string $Action, ?array $Params = null): bool
+	public function process(string $Action, ?array $Params = null): mixed
 	{
 		if(!$Action)
 		{


### PR DESCRIPTION
Updated the return type of `Invoker::process()` method from `bool` to `mixed` because `ICommand::execute()` method returns `mixed` 
